### PR TITLE
updated coverage plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -26,9 +26,7 @@
         ["babel-plugin-espower", {
           "embedAst": true
         }],
-        ["__coverage__", {
-          "ignore": [".spec.js","webpack/"]
-        }],
+        ["istanbul"],
         ["babel-plugin-webpack-aliases", {
           "config": "./webpack/webpack.config.test.js"
         }],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "fontpath": "./src/app/layout/fonts"
   },
   "nyc": {
+    "include": "src",
+    "exclude": [
+      "**/*.spec.js"
+    ],
     "reporter": [
+      "lcov",
       "text"
     ],
     "report-dir": "./coverage",
@@ -79,6 +84,7 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-__coverage__": "^11.0.0",
     "babel-plugin-espower": "^2.3.1",
+    "babel-plugin-istanbul": "^1.0.3",
     "babel-plugin-react-intl": "^2.1.3",
     "babel-plugin-system-import-transformer": "^2.2.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",


### PR DESCRIPTION
hit with this https://github.com/istanbuljs/nyc/issues/306

so switch from   https://github.com/dtinth/babel-plugin-__coverage__ to https://github.com/istanbuljs/babel-plugin-istanbul . I think this plugin is maintained officially.
